### PR TITLE
Remove Arrayification of Event's data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+## Next Release
+
+* [#PR_NUMBER](https://github.com/jouba/pull/PR_NUMBER): DESCRIPTION. - [@CONTRIBUTOR](https://github.com/CONTRIBUTOR).
+
+* [#6](https://github.com/jouba/pull/6): Add changelog and contributing files. - [@gregory](https://github.com/gregory).
+* [#8](https://github.com/jouba/pull/8): [fix ruby <2 to_h -> to_hash](https://github.com/gregory/jouba/issues/7) . - [@gregory](https://github.com/gregory).
+* [#1](https://github.com/gregory/jouba/pull/1): Fix README, remove unnecessary include in spec. - [@diegodurs](https://github.com/diegodurs).
+
+## 1.1.0
+
+* fixed [#2](https://github.com/gregory/jouba/issues/2): Rake tasks failing upon inclusion into Gemfile. - [@gregory](https://github.com/gregory).
+
+## 1.0.1
+
+* Changed the api and improvate the readme.
+
+## 1.0.0
+* Here we go :)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to Jouba
+
+You're encouraged to submit [pull requests](https://github.com/gregory/jouba/pulls), [propose features, and discuss issues](https://github.com/gregory/jouba/issues).
+
+We'll use issues to manage anything that is code related: bugs or features so please, before doing anything, create a new issue and make sure this is not a duplaction.
+If this is not code related(readme or other stuffs), a pull request is enough.
+
+If this is a bug, explain the issue(short description is better), add the bug label then open a pull request that reproduce that bug.
+
+If this is a feature, please explain what you are trying to do, add the feature label then open a pull request with a spec that would show what you want to do
+
+At this point, your spec should be failing.
+
+Here is how to open a pull request:
+
+#### Fork the Project
+
+Fork the [project on Github](https://github.com/gregory/jouba) and check out your copy.
+
+```
+git clone https://github.com/CONTRIBUTOR/jouba.git
+cd jouba
+git remote add upstream https://github.com/gregory/jouba.git
+```
+
+#### Create a Feature Branch
+
+Make sure your fork is up-to-date and create a topic branch for your feature or bug fix.
+Make sure your branch is prefixed by the related issue number
+
+```
+git checkout master
+git pull upstream master
+git checkout -b issue_2_improve_something
+```
+
+#### Bundle Install and Test
+
+Ensure that you can build the project and run tests.
+
+```
+bundle install
+bundle exec rake
+```
+
+#### Write Tests
+
+Try to write a test that reproduces the problem you're trying to fix or describes a feature that you want to build.
+
+If this is an issue, try to reproduce the problem you are trying to fix or describes in `specs/issues/`.
+
+Please prefix it with the **issue number**  and a short description.
+
+Ex: let's say there is an issue opened in Aggregate#emit (let's say issue num 4):
+
+```rb
+# in specs/issues/aggregate.rb
+require 'spec_helper'
+require 'jouba/aggregate'
+
+describe Jouba::Aggregate do
+  describe '#emit()' do
+    context 'special context' do
+      describe "#4: [the issue]" do
+      end
+    end
+  end
+end
+```
+
+If this is a feature you want to build, try to highlight it in `specs/features`.
+Ex: let's say you want to add new behaviour on Aggregate#emit (discussed on issue 5)
+
+```rb
+# in specs/issues/aggregate.rb
+require 'spec_helper'
+require 'jouba/aggregate'
+
+describe Jouba::Aggregate do
+  describe '#emit()' do
+    feature "#5: [what is the new behaviour]" do
+    end
+  end
+end
+```
+
+We definitely appreciate pull requests that highlight or reproduce a problem, even without a fix.
+
+#### Write Code
+
+Implement your feature or bug fix.
+
+Ruby style is enforced with [Rubocop](https://github.com/bbatsov/rubocop), run `bundle exec rubocop` and fix any style issues highlighted.
+
+Make sure that `bundle exec rake` completes without errors.
+
+#### Write Documentation
+
+Document any external behavior in the [README](README.md).
+
+#### Update Changelog
+
+Add a line to [CHANGELOG](CHANGELOG.md) under *Next Release*. Make it look like every other line, including your name and link to your Github account.
+
+#### Commit Changes
+
+Make sure git knows your name and email address:
+
+```
+git config --global user.name "Your Name"
+git config --global user.email "contributor@example.com"
+```
+
+Writing good commit logs is important. A commit log should describe what changed and why.
+Please make sure to prepend your commit message with `Issue **issue number**`
+ex of commit message: '#5 - Description of the feature or issue'
+
+```
+git add ...
+git commit
+```
+
+#### Push
+
+```
+git push origin my-feature-branch
+```
+
+#### Make a Pull Request
+
+Go to https://github.com/contributor/jouba and select your feature branch. Click the 'Pull Request' button and fill out the form. Pull requests are usually reviewed within a few days.
+
+#### Rebase
+
+If you've been working on a change for a while, rebase with upstream/master.
+
+```
+git fetch upstream
+git rebase upstream/master
+git push origin my-feature-branch -f
+```
+
+#### Update CHANGELOG Again
+
+Update the [CHANGELOG](CHANGELOG.md) with the pull request number. A typical entry looks as follows.
+
+```
+* [#123](https://github.com/CONTRIBUTOR/pull/123): [Added products resource](https://github.com/issues/100) - [@contributor](https://github.com/contributor).
+```
+
+Amend your previous commit and force push the changes.
+
+```
+git commit --amend
+git push origin my-feature-branch -f
+```
+
+#### Check on Your Pull Request
+
+Go back to your pull request after a few minutes and see whether it passed muster with Travis-CI. Everything should look green, otherwise fix issues and amend your commit as described above.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Jouba
 
 [![Join the chat at https://gitter.im/gregory/jouba](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gregory/jouba?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Dependency Status](https://gemnasium.com/gregory/jouba.svg)](https://gemnasium.com/gregory/jouba)
+[![Build](https://travis-ci.org/gregory/jouba.png?branch=master)](https://travis-ci.org/gregory/jouba)
+[![Coverage](https://coveralls.io/repos/gregory/jouba/badge.svg?branch=master)](https://coveralls.io/r/gregory/jouba?branch=master)
 
 ![](https://dl.dropboxusercontent.com/u/19927862/jouba.png)
-
 
 ## WTF?
 
@@ -14,20 +16,17 @@ Jouba aims to be a minimalist framework in pure ruby for [event sourcing](http:/
 **Event sourcing**:
 > The fundamental idea of Event Sourcing is that of ensuring every change to the state of an application is captured in an event object, and that these event objects are themselves stored in the sequence they were applied for the same lifetime as the application state itself.
 
-
-**CQRS**: 
+**CQRS**:
 > It's a pattern that I first heard described by Greg Young. At its heart is a simple notion that you can use a different model to update information than the model you use to read information.
 
 ## FAQ:
 
 * Is it in production yet?
   * Not that i know of. In my case, not yet since i've been pretty busy with other stuffs and this was initially part of a side project, but i should be pretty reactive for PR/issues so feel free to use/improve it.
-  
-  
 
 ## Pub/Sub
 
-Jouba ships with a minimalist API to emit events and subscribe listeners (listeners could operate asynchronously) and retrieve events from the store that is set at `Jouba.config.Store` (by default this will be an [in memory store](https://github.com/gregory/jouba/blob/master/lib/jouba/store.rb#L47). 
+Jouba ships with a minimalist API to emit events and subscribe listeners (listeners could operate asynchronously) and retrieve events from the store that is set at `Jouba.config.Store` (by default this will be an [in memory store](https://github.com/gregory/jouba/blob/master/lib/jouba/store.rb#L47).
 
 At it's core, it relies on the excellent [wisper](https://github.com/krisleech/wisper) gem so you have all it's awesomeness for free.
 
@@ -38,7 +37,7 @@ Jouba.subscribe(Logger.new, on: /.*/, with: :log)
 Jouba.subscribe(Graphite, on: /us.*/, with: :post, async: true).on_error do |error, name,payload|
 	#DO SOMETHING
 end
-	
+
 Jouba.stream('us.computer1.cpu').since(1.month.ago).where({value: ->(v) { v >= 20 }})
 
 class Logger
@@ -58,12 +57,11 @@ end
 
 You are free to implement an Event Store as soon as they define `self.stream`and `self.track` methods.
 
-
 ```ruby
 
   class Store < ActiveRecord::Base
     set_table_name :events
- 
+
     scope :since, -> (time) { where('timestamp >= ?', time) }
 
     def self.stream(key, params={})
@@ -74,7 +72,6 @@ You are free to implement an Event Store as soon as they define `self.stream`and
       create serialized_event
     end
   end
-  
 
   Jouba.config.Store = Store
   Jouba.emit('us.computer1', :disk, {value: 60})
@@ -103,7 +100,7 @@ A UUID will be generated for any new aggregate, [even in distributed environment
 require 'jouba/aggregate'
 class Customer < Hashie::Dash
   include Jouba::Aggregate.new(prefix: :on)
-  
+
   property :uuid
   property :name
 
@@ -144,7 +141,7 @@ Event Sourcing might seem overkill, but this is a little cost comparing to [the 
 
 ## Event (indicate that something has happened)
 
-If you are unhappy with the structure of Jouba::Event, feel free to implement your own! 
+If you are unhappy with the structure of Jouba::Event, feel free to implement your own!
 
 You can access/update to the main parts of jouba from the config
 
@@ -162,26 +159,25 @@ Jouba.config.Event = MyEvent
 
 ## Event Key (generate a key based on the aggregate)
 
-If you feels unhappy with the way Jouba::Key is building keys in the aggregate, feel free to implement your own! 
-
+If you feels unhappy with the way Jouba::Key is building keys in the aggregate, feel free to implement your own!
 
 ```ruby
-	
+
 class MyKey
   attr_reader :class_name, :uuid
-	  
+
   def initialize(class_name, uuid);
     @class_name, @uuid = class_name, uuid
   end
-	  
+
   def self.serialize(class_name, uuid); end #return a string of a key
   def self.deserialize(string); end # return a new MyKey
 end
 ```
 
-## Repository 
+## Repository
 
-Repository is a CQRS concept where you should use repositories to fetch your data for read only. You'll need to keep your repository up to date with all the latest changes. 
+Repository is a CQRS concept where you should use repositories to fetch your data for read only. You'll need to keep your repository up to date with all the latest changes.
 The way to achieve this with jouba is by having the repository to subscribe to the aggregates. Repository will ideally translate events into state.
 
 ```ruby
@@ -219,11 +215,10 @@ The way to achieve this with jouba is by having the repository to subscribe to t
 
 ## Cache
 
-If you feels unhappy with Jouba::Cache, feel free to implement your own! 
-
+If you feels unhappy with Jouba::Cache, feel free to implement your own!
 
 ```ruby
-	
+
 class MyCache
   def fetch(_)
     yield
@@ -236,11 +231,11 @@ end
 
 Jouba.config.Cache = MyCache.new
 ```
-## Why Jouba? 
+## Why Jouba?
 
 Jouba is the name of the parrot i grew up with. He never talked but made a hell lot of noise. Going down the path of event sourcing, you'll have a lot of noise first, but then you'll figure out what to do with it.
 
-## TODO: 
+## TODO:
 
 * [ ] Better doc (this is a draft :))
 * [ ] Locking Mechanisme

--- a/lib/jouba/aggregate.rb
+++ b/lib/jouba/aggregate.rb
@@ -25,8 +25,8 @@ module Jouba
     end
 
     module InstanceMethods
-      def emit(name, *args)
-        Jouba.emit(to_key, name, args) do |event|
+      def emit(name, data)
+        Jouba.emit(to_key, name, data) do |event|
           apply_event(event)
           Jouba.Cache.refresh(to_key, self) { event.track }
           publish(event.name, event.data)
@@ -34,7 +34,7 @@ module Jouba
       end
 
       def replay(event)
-        send __callback_method__(:"#{event.name}"), *event.data
+        send __callback_method__(:"#{event.name}"), event.data
       end
       alias_method :apply_event, :replay
 


### PR DESCRIPTION
Introducing a breaking change.

With this commit, we restrict aggregate to emit event with only one
object as a payload instead splashing it into an array. 
It seems to reasonnable to not change the payload of emited event. It is confusing, and adds little benefits in terms of feature.

What we loose is the ability to write code like this:

``` ruby
class SomeAggregate
  def on_created(value1, value2)
  end
end

aggregate.emit(:created, value1, value2)
```

Instead we need to transform arguments into an array or an hash like so:

``` ruby
class SomeAggregate
  def on_created(args)
    value1, value2 = *args
  end
end

aggregate.emit(:created, [value1, value2])
```
